### PR TITLE
Fix TypeScript error in `consts.d.ts`

### DIFF
--- a/consts.d.ts
+++ b/consts.d.ts
@@ -2,5 +2,6 @@ declare module 'consts:*' {
     /**
      * Constant that will be inlined by Rollup and rollup-plugin-consts.
      */
-    export default any;
+    const constant: any;
+    export default constant;
 }


### PR DESCRIPTION
Previously, TypeScript would complain that `any` is a type but is used as a value, and there's no straightforward way to ignore that error downstream other than the `skipLibCheck` option, which has [a number of downsides](https://www.testim.io/blog/typescript-skiplibcheck/).

```
node_modules/rollup-plugin-consts/consts.d.ts:5:20 - error TS2693: 'any' only refers to a type, but is being used as a value here.

5     export default any;
                     ~~~
```