### PR TITLE
Add "prepare" task

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "consts.d.ts"
     ],
     "scripts": {
+        "prepare": "npm run build",
         "build": "rollup -c",
         "pretest": "npm run build",
         "test": "jest && prettier \"src/*.js\" \"test/**/*.js\" \"*.{js,ts,md}\" --check",


### PR DESCRIPTION
I believe this will help users npm install to the github url directly (via `npm i https://github.com/NotWoods/rollup-plugin-consts`). Additionally, adds some convenience when publishing.